### PR TITLE
Add x_content to plain page

### DIFF
--- a/production/plain_page.html
+++ b/production/plain_page.html
@@ -357,6 +357,9 @@
                     </ul>
                     <div class="clearfix"></div>
                   </div>
+                  <div class="x_content">
+                      Add content to the page ...
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
To avoid missing a class 'x_content' when prototyping a new page