### PR TITLE
Fixed sidebar functionality when collapsed

### DIFF
--- a/build/js/custom.js
+++ b/build/js/custom.js
@@ -61,16 +61,21 @@ $(document).ready(function() {
             $BODY.removeClass('nav-md').addClass('nav-sm');
 
             if ($SIDEBAR_MENU.find('li').hasClass('active')) {
+                if ($SIDEBAR_MENU.find('li.active').find('ul')) {
+                    $SIDEBAR_MENU.find('li.active').find('ul').hide();
+                }
                 $SIDEBAR_MENU.find('li.active').addClass('active-sm').removeClass('active');
             }
         } else {
             $BODY.removeClass('nav-sm').addClass('nav-md');
 
+            if ($SIDEBAR_MENU.find('li.active-sm').find('ul')) {
+                $SIDEBAR_MENU.find('li.active-sm').find('ul').show();
+            }
             if ($SIDEBAR_MENU.find('li').hasClass('active-sm')) {
                 $SIDEBAR_MENU.find('li.active-sm').addClass('active').removeClass('active-sm');
             }
         }
-
         setContentHeight();
     });
 

--- a/production/index.html
+++ b/production/index.html
@@ -1013,7 +1013,7 @@
     <script src="js/datepicker/daterangepicker.js"></script>
 
     <!-- Custom Theme Scripts -->
-    <script src="../build/js/custom.min.js"></script>
+    <script src="../build/js/custom.js"></script>
 
     <!-- Flot -->
     <script>


### PR DESCRIPTION
Before, when the sidebar collapsed, the inner li elements (if any) would not collapse along with it. The changes to 'build/js/custom.css' show the fixes - I guess if you like it you can take it and minify it to update 'build/js/custom.min.css' in your repo! 

** If you would like to reproduce these changes, don't forget to change the stylesheet reference
in whatever page to the new 'build/js/custom.css' (or minify it and update 'build/js/custom.min.css' to see it in everything)!

Thanks for the template!