### PR TITLE
Remove unused plugin link

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ If `gulp` is installed, follow the steps below.
 * jVectorMap
 * moment.js
 * Morris.js - pretty time-series line graphs
-* jquery-nicescroll plugin
 * PNotify - Awesome JavaScript notifications
 * NProgress
 * Pace

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -395,10 +395,6 @@
                                     <td><a href="http://www.jacklmoore.com/autosize/">http://www.jacklmoore.com/autosize/</a></td>
                                 </tr>
                                 <tr>
-                                    <td>Nice scroll</td>
-                                    <td><a href="http://areaaperta.com/nicescroll/">http://areaaperta.com/nicescroll/</a></td>
-                                </tr>
-                                <tr>
                                     <td>C3 charts</td>
                                     <td><a href="http://c3js.org/">http://c3js.org/</a></td>
                                 </tr>

--- a/documentation/index_cn.html
+++ b/documentation/index_cn.html
@@ -473,10 +473,6 @@
                                     <td><a href="http://www.jacklmoore.com/autosize/">http://www.jacklmoore.com/autosize/</a></td>
                                 </tr>
                                 <tr>
-                                    <td>Nice scroll</td>
-                                    <td><a href="http://areaaperta.com/nicescroll/">http://areaaperta.com/nicescroll/</a></td>
-                                </tr>
-                                <tr>
                                     <td>C3 charts</td>
                                     <td><a href="http://c3js.org/">http://c3js.org/</a></td>
                                 </tr>


### PR DESCRIPTION
jquery nicescroll isn't being used anywhere in the theme.