### PR TITLE
Remove deprecated bower.json option: version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "gentelella",
-  "version": "1.3.0",
   "homepage": "https://colorlib.com/polygon/gentelella/index.html",
   "authors": [
     "Aigars Silkalns",


### PR DESCRIPTION
`version` option for `bower.json` it's deprecated and ignored by bower, as you can read in *`bower.json` specification*:

> https://github.com/bower/spec/blob/master/json.md#version
  Use git or svn tags instead. This field is ignored by Bower.

Ref.: #254