### PR TITLE
fix css badge style name in typography page

### DIFF
--- a/production/typography.html
+++ b/production/typography.html
@@ -346,7 +346,7 @@
                       <span class="label label-info">Info</span>
                       <span class="label label-warning">Warning</span>
                       <span class="label label-danger">Danger</span>
-                      <span class="badge badge-success">42</span>
+                      <span class="badge bg-green">42</span>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
I fix the wrong css name of badge-success to bg-green.