### PR TITLE
dataTable fixed header bug on sidebar toggle

### DIFF
--- a/build/css/custom.css
+++ b/build/css/custom.css
@@ -762,6 +762,9 @@ a:focus {
     position: absolute;
     top: 0
 }
+.nav-md ul.nav.child_menu li:last-child::after {
+  bottom: 50%;
+}
 .nav.side-menu>li>a,
 .nav.child_menu>li>a {
     color: #E7E7E7;

--- a/build/js/custom.js
+++ b/build/js/custom.js
@@ -114,6 +114,8 @@ $MENU_TOGGLE.on('click', function() {
 	$BODY.toggleClass('nav-md nav-sm');
 
 	setContentHeight();
+
+	$('.dataTable').each ( function () { $(this).dataTable().fnDraw(); });
 });
 
 	// check active menu

--- a/src/js/custom.js
+++ b/src/js/custom.js
@@ -68,6 +68,8 @@ $(document).ready(function() {
         $BODY.toggleClass('nav-md nav-sm');
 
         setContentHeight();
+
+        $('.dataTable').each ( function () { $(this).dataTable().fnDraw(); });
     });
 
     // check active menu

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -546,6 +546,9 @@ a:hover, a:focus {
   position: absolute;
   top: 0;
 }
+.nav-md ul.nav.child_menu li:last-child::after {
+  bottom: 50%;
+}
 .nav.side-menu>li>a, .nav.child_menu>li>a {
   color: #E7E7E7;
   font-weight: 500;


### PR DESCRIPTION
Hi!

I've found a bug that if you've a fixed header dataTable at page, toggle the sidebar, the fixed header will not resize. A little fix added to custom.js at sidebar toggle to redraw every dataTable on the page.

![screen shot 2017-03-30 at 10 52 28 am](https://cloud.githubusercontent.com/assets/1548784/24508062/ba8a9b34-1538-11e7-8eb7-aa719a918521.png)
