### PR TITLE
Visual regression tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ nbproject
 npm-debug.log
 node_modules
 .sass-cache
+failures/
+screenshots/*.fail.png
+screenshots/*.diff.png

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ nbproject
 npm-debug.log
 node_modules
 .sass-cache
-failures/
-screenshots/*.fail.png
-screenshots/*.diff.png
+tests/screenshots/
+tests/failures/
+tests/screenshots/*.fail.png
+tests/screenshots/*.diff.png

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,6 +40,7 @@ gulp.task('sass-minify', function() {
 
 gulp.task('browser-sync', function() {
     browserSync.init({
+        notify: false,
         server: {
             baseDir: './'
         },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.0",
   "description": "Gentelella Admin is a free to use Bootstrap admin template",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "casperjs test tests/visual-regression-tests.js"
   },
   "repository": {
     "type": "git",
@@ -32,11 +32,14 @@
   "homepage": "https://github.com/puikinsh/gentelella#readme",
   "devDependencies": {
     "browser-sync": "^2.12.10",
+    "casperjs": "^1.1.4",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-concat": "^2.6.0",
     "gulp-rename": "^1.2.2",
     "gulp-ruby-sass": "^2.0.6",
-    "gulp-uglify": "^1.5.3"
+    "gulp-uglify": "^1.5.3",
+    "phantomcss": "^1.1.5",
+    "phantomjs-prebuilt": "^2.1.14"
   }
 }

--- a/tests/visual-regression-tests.js
+++ b/tests/visual-regression-tests.js
@@ -22,24 +22,6 @@ casper.test.begin('Gentelella visual tests', function (test) {
     screenshotRoot: fs.absolute(fs.workingDirectory + '/tests/screenshots'),
     failedComparisonsRoot: fs.absolute(fs.workingDirectory + '/tests/failures'),
     addLabelToFailedImage: true,
-
-    /*
-    fileNameGetter: function overide_file_naming(){},
-    onPass: function passCallback(){},
-    onFail: function failCallback(){},
-    onTimeout: function timeoutCallback(){},
-    onComplete: function completeCallback(){},
-    hideElements: '#thing.selector',
-    outputSettings: {
-      errorColor: {
-        red: 255,
-        green: 255,
-        blue: 0
-      },
-      errorType: 'movement',
-      transparency: 0.3
-    }
-    */
   });
 
   // CasperJS error handlers.
@@ -73,15 +55,209 @@ casper.test.begin('Gentelella visual tests', function (test) {
         phantomcss.screenshot('body', 'index-with-user-profile-dropdown');
       },
       function timeout() {
-        casper.test.fail('Should see ');
+        casper.test.fail('Should see user profile dropdown.');
       }
     );
   });
 
   // Test screenshot: login.html login-form.
-  casper.thenOpen('http://localhost:3000/./production/index.html', function () {
+  casper.thenOpen('http://localhost:3000/./production/login.html', function () {
     phantomcss.screenshot('body', 'login-form');
   });
+
+  // Test screenshot: login.html register-form.
+  casper.then(function () {
+    casper.click('.to_register');
+
+    // wait for modal to fade-in
+    casper.wait(1000,
+      function done() {
+        phantomcss.screenshot('body', 'register-form');
+      }
+    );
+  });
+
+  // Test screenshot: calendar.html
+  casper.thenOpen('http://localhost:3000/./production/calendar.html', function () {
+    phantomcss.screenshot('body', 'calendar');
+  });
+
+  // Test screenshot: chartjs.html
+  casper.thenOpen('http://localhost:3000/./production/chartjs.html', function () {
+    phantomcss.screenshot('body', 'chartjs');
+  });
+
+  // Test screenshot: contacts.html
+  casper.thenOpen('http://localhost:3000/./production/contacts.html', function () {
+    phantomcss.screenshot('body', 'contacts');
+  });
+
+  // Test screenshot: echarts.html
+  casper.thenOpen('http://localhost:3000/./production/echarts.html', function () {
+    phantomcss.screenshot('body', 'echarts');
+  });
+
+  // Test screenshot: e_commerce.html
+  casper.thenOpen('http://localhost:3000/./production/e_commerce.html', function () {
+    phantomcss.screenshot('body', 'e_commerce');
+  });
+
+  // Test screenshot: fixed_footer.html
+  casper.thenOpen('http://localhost:3000/./production/fixed_footer.html', function () {
+    phantomcss.screenshot('body', 'fixed_footer');
+  });
+
+  // Test screenshot: fixed_sidebar.html
+  casper.thenOpen('http://localhost:3000/./production/fixed_sidebar.html', function () {
+    phantomcss.screenshot('body', 'fixed_sidebar');
+  });
+
+  // Test screenshot: form_advanced.html
+  casper.thenOpen('http://localhost:3000/./production/form_advanced.html', function () {
+    phantomcss.screenshot('body', 'form_advanced');
+  });
+
+  // Test screenshot: form_buttons.html
+  casper.thenOpen('http://localhost:3000/./production/form_buttons.html', function () {
+    phantomcss.screenshot('body', 'form_buttons');
+  });
+
+  // Test screenshot: form.html
+  casper.thenOpen('http://localhost:3000/./production/form.html', function () {
+    phantomcss.screenshot('body', 'form');
+  });
+
+  // Test screenshot: form_upload.html
+  casper.thenOpen('http://localhost:3000/./production/form_upload.html', function () {
+    phantomcss.screenshot('body', 'form_upload');
+  });
+
+  // Test screenshot: form_validation.html
+  casper.thenOpen('http://localhost:3000/./production/form_validation.html', function () {
+    phantomcss.screenshot('body', 'form_validation');
+  });
+
+  // Test screenshot: form_wizards.html
+  casper.thenOpen('http://localhost:3000/./production/form_wizards.html', function () {
+    phantomcss.screenshot('body', 'form_wizards');
+  });
+
+  // Test screenshot: general_elements.html
+  casper.thenOpen('http://localhost:3000/./production/general_elements.html', function () {
+    phantomcss.screenshot('body', 'general_elements');
+  });
+
+  // Test screenshot: glyphicons.html
+  casper.thenOpen('http://localhost:3000/./production/glyphicons.html', function () {
+    phantomcss.screenshot('body', 'glyphicons');
+  });
+
+  // Test screenshot: icons.html
+  casper.thenOpen('http://localhost:3000/./production/icons.html', function () {
+    phantomcss.screenshot('body', 'icons');
+  });
+
+  // Test screenshot: inbox.html
+  casper.thenOpen('http://localhost:3000/./production/inbox.html', function () {
+    phantomcss.screenshot('body', 'inbox');
+  });
+
+  // Test screenshot: invoice.html
+  casper.thenOpen('http://localhost:3000/./production/invoice.html', function () {
+    phantomcss.screenshot('body', 'invoice');
+  });
+
+  // Test screenshot: map.html
+  casper.thenOpen('http://localhost:3000/./production/map.html', function () {
+    phantomcss.screenshot('body', 'map');
+  });
+
+  // Test screenshot: media_gallery.html
+  casper.thenOpen('http://localhost:3000/./production/media_gallery.html', function () {
+    phantomcss.screenshot('body', 'media_gallery');
+  });
+
+  // Test screenshot: morisjs.html
+  casper.thenOpen('http://localhost:3000/./production/morisjs.html', function () {
+    phantomcss.screenshot('body', 'morisjs');
+  });
+
+  // Test screenshot: other_charts.html
+  casper.thenOpen('http://localhost:3000/./production/other_charts.html', function () {
+    phantomcss.screenshot('body', 'other_charts');
+  });
+
+  // Test screenshot: page_403.html
+  casper.thenOpen('http://localhost:3000/./production/page_403.html', function () {
+    phantomcss.screenshot('body', 'page_403');
+  });
+
+  // Test screenshot: page_404.html
+  casper.thenOpen('http://localhost:3000/./production/page_404.html', function () {
+    phantomcss.screenshot('body', 'page_404');
+  });
+
+  // Test screenshot: page_500.html
+  casper.thenOpen('http://localhost:3000/./production/page_500.html', function () {
+    phantomcss.screenshot('body', 'page_500');
+  });
+
+  // Test screenshot: plain_page.html
+  casper.thenOpen('http://localhost:3000/./production/plain_page.html', function () {
+    phantomcss.screenshot('body', 'plain_page');
+  });
+
+  // Test screenshot: pricing_tables.html
+  casper.thenOpen('http://localhost:3000/./production/pricing_tables.html', function () {
+    phantomcss.screenshot('body', 'pricing_tables');
+  });
+
+  // Test screenshot: profile.html
+  casper.thenOpen('http://localhost:3000/./production/profile.html', function () {
+    phantomcss.screenshot('body', 'profile');
+  });
+
+  // Test screenshot: project_detail.html
+  casper.thenOpen('http://localhost:3000/./production/project_detail.html', function () {
+    phantomcss.screenshot('body', 'project_detail');
+  });
+
+  // Test screenshot: projects.html
+  casper.thenOpen('http://localhost:3000/./production/projects.html', function () {
+    phantomcss.screenshot('body', 'projects');
+  });
+
+  // Test screenshot: projects.html
+  casper.thenOpen('http://localhost:3000/./production/projects.html', function () {
+    phantomcss.screenshot('body', 'projects');
+  });
+
+  // Test screenshot: tables.html
+  casper.thenOpen('http://localhost:3000/./production/tables.html', function () {
+    phantomcss.screenshot('body', 'tables');
+  });
+
+  // Test screenshot: tables_dynamic.html
+  casper.thenOpen('http://localhost:3000/./production/tables_dynamic.html', function () {
+    phantomcss.screenshot('body', 'tables_dynamic');
+  });
+
+  // Test screenshot: typography.html
+  casper.thenOpen('http://localhost:3000/./production/typography.html', function () {
+    phantomcss.screenshot('body', 'typography');
+  });
+
+  // Test screenshot: widgets.html
+  casper.thenOpen('http://localhost:3000/./production/widgets.html', function () {
+    phantomcss.screenshot('body', 'widgets');
+  });
+
+  // Test screenshot: widgets.html
+  casper.thenOpen('http://localhost:3000/./production/widgets.html', function () {
+    phantomcss.screenshot('body', 'widgets');
+  });
+
+
 
   // Check all screenshots.
   casper.then(function now_check_the_screenshots() {
@@ -96,3 +272,13 @@ casper.test.begin('Gentelella visual tests', function (test) {
     casper.test.done();
   });
 });
+
+/**
+ * Skipped pages:
+ * production/xx.html
+ * production/chartjs2.html
+ * production/index2.html
+ * production/index3.html
+ * production/level2.html
+ */
+

--- a/tests/visual-regression-tests.js
+++ b/tests/visual-regression-tests.js
@@ -1,0 +1,112 @@
+var phantomcss = require('phantomcss');
+
+function _onPass(test) {
+  console.log('\n');
+  var name = 'Should look the same ' + test.filename;
+  casper.test.pass(name, { name: name });
+}
+
+function _onFail(test) {
+  console.log('\n');
+  var name = 'Should look the same ' + test.filename;
+  casper.test.fail(name, { name: name, message: 'Looks different (' + test.mismatch + '% mismatch) ' + test.failFile });
+}
+
+casper.test.begin('Gentelella visual tests', function (test) {
+  phantomcss.init({
+    rebase: casper.cli.get("rebase"),
+    // SlimerJS needs explicit knowledge of this Casper, and lots of absolute paths
+    casper: casper,
+    libraryRoot: fs.absolute(fs.workingDirectory + ''),
+    screenshotRoot: fs.absolute(fs.workingDirectory + '/screenshots'),
+    failedComparisonsRoot: fs.absolute(fs.workingDirectory + '/failures'),
+    addLabelToFailedImage: true,
+
+    /*
+    screenshotRoot: '/screenshots',
+    failedComparisonsRoot: '/failures'
+    casper: specific_instance_of_casper,
+    libraryRoot: '/phantomcss',
+    fileNameGetter: function overide_file_naming(){},
+    onPass: function passCallback(){},
+    onFail: function failCallback(){},
+    onTimeout: function timeoutCallback(){},
+      onComplete: function completeCallback(){},
+      hideElements: '#thing.selector',
+      addLabelToFailedImage: true,
+      outputSettings: {
+        errorColor: {
+          red: 255,
+          green: 255,
+          blue: 0
+        },
+        errorType: 'movement',
+        transparency: 0.3
+      }
+      */
+  });
+
+  casper.on('remote.message', function (msg) {
+    this.echo(msg);
+  });
+  casper.on('error', function (err) {
+    this.die("PhantomJS has errored: " + err);
+  });
+  casper.on('resource.error', function (err) {
+    casper.log('Resource load error: ' + err, 'warning');
+  });
+
+  // The test scenario
+  casper.start();
+  casper.viewport(1920, 1080);
+  casper.thenOpen('http://localhost:3000/./production/index.html', function () {
+    phantomcss.screenshot('body', 'index');
+  });
+
+  casper.then(function () {
+    casper.click('.user-profile.dropdown-toggle');
+    // wait for modal to fade-in
+    casper.waitForSelector('li.open .user-profile.dropdown-toggle',
+      function success() {
+        phantomcss.screenshot('body', 'index-with-user-profile-dropdown');
+      },
+      function timeout() {
+        casper.test.fail('Should see coffee machine');
+      }
+    );
+  });
+  casper.then(function () {
+    casper.click('#cappuccino-button');
+    phantomcss.screenshot('#myModal', 'cappuccino success');
+  });
+  casper.then(function () {
+    casper.click('#close');
+    // wait for modal to fade-out
+    casper.waitForSelector('#myModal[style*="display: none"]',
+      function success() {
+        phantomcss.screenshot({
+          'Coffee machine close success': {
+            selector: '#coffee-machine-wrapper',
+            ignore: '.selector'
+          },
+          'Coffee machine button success': '#coffee-machine-button'
+        });
+      },
+      function timeout() {
+        casper.test.fail('Should be able to walk away from the coffee machine');
+      }
+    );
+  });
+  casper.then(function now_check_the_screenshots() {
+    // compare screenshots
+    phantomcss.compareAll();
+  });
+  /*
+  Casper runs tests
+  */
+  casper.run(function () {
+    console.log('\nTHE END.');
+    // phantomcss.getExitStatus() // pass or fail?
+    casper.test.done();
+  });
+});

--- a/tests/visual-regression-tests.js
+++ b/tests/visual-regression-tests.js
@@ -1,3 +1,4 @@
+var fs = require('fs');
 var phantomcss = require('phantomcss');
 
 function _onPass(test) {
@@ -17,35 +18,31 @@ casper.test.begin('Gentelella visual tests', function (test) {
     rebase: casper.cli.get("rebase"),
     // SlimerJS needs explicit knowledge of this Casper, and lots of absolute paths
     casper: casper,
-    libraryRoot: fs.absolute(fs.workingDirectory + ''),
-    screenshotRoot: fs.absolute(fs.workingDirectory + '/screenshots'),
-    failedComparisonsRoot: fs.absolute(fs.workingDirectory + '/failures'),
+    libraryRoot: fs.absolute(fs.workingDirectory + '/node_modules/phantomcss'),
+    screenshotRoot: fs.absolute(fs.workingDirectory + '/tests/screenshots'),
+    failedComparisonsRoot: fs.absolute(fs.workingDirectory + '/tests/failures'),
     addLabelToFailedImage: true,
 
     /*
-    screenshotRoot: '/screenshots',
-    failedComparisonsRoot: '/failures'
-    casper: specific_instance_of_casper,
-    libraryRoot: '/phantomcss',
     fileNameGetter: function overide_file_naming(){},
     onPass: function passCallback(){},
     onFail: function failCallback(){},
     onTimeout: function timeoutCallback(){},
-      onComplete: function completeCallback(){},
-      hideElements: '#thing.selector',
-      addLabelToFailedImage: true,
-      outputSettings: {
-        errorColor: {
-          red: 255,
-          green: 255,
-          blue: 0
-        },
-        errorType: 'movement',
-        transparency: 0.3
-      }
-      */
+    onComplete: function completeCallback(){},
+    hideElements: '#thing.selector',
+    outputSettings: {
+      errorColor: {
+        red: 255,
+        green: 255,
+        blue: 0
+      },
+      errorType: 'movement',
+      transparency: 0.3
+    }
+    */
   });
 
+  // CasperJS error handlers.
   casper.on('remote.message', function (msg) {
     this.echo(msg);
   });
@@ -57,53 +54,42 @@ casper.test.begin('Gentelella visual tests', function (test) {
   });
 
   // The test scenario
+  // Start test suite
   casper.start();
   casper.viewport(1920, 1080);
-  casper.thenOpen('http://localhost:3000/./production/index.html', function () {
+
+  // Test screenshot: index.html.
+  casper.open('http://localhost:3000/./production/index.html', function () {
     phantomcss.screenshot('body', 'index');
   });
 
+  // // index.html user-profile dropdown.
   casper.then(function () {
-    casper.click('.user-profile.dropdown-toggle');
+    casper.click('.user-profile');
+
     // wait for modal to fade-in
     casper.waitForSelector('li.open .user-profile.dropdown-toggle',
       function success() {
         phantomcss.screenshot('body', 'index-with-user-profile-dropdown');
       },
       function timeout() {
-        casper.test.fail('Should see coffee machine');
+        casper.test.fail('Should see ');
       }
     );
   });
-  casper.then(function () {
-    casper.click('#cappuccino-button');
-    phantomcss.screenshot('#myModal', 'cappuccino success');
+
+  // Test screenshot: login.html login-form.
+  casper.thenOpen('http://localhost:3000/./production/index.html', function () {
+    phantomcss.screenshot('body', 'login-form');
   });
-  casper.then(function () {
-    casper.click('#close');
-    // wait for modal to fade-out
-    casper.waitForSelector('#myModal[style*="display: none"]',
-      function success() {
-        phantomcss.screenshot({
-          'Coffee machine close success': {
-            selector: '#coffee-machine-wrapper',
-            ignore: '.selector'
-          },
-          'Coffee machine button success': '#coffee-machine-button'
-        });
-      },
-      function timeout() {
-        casper.test.fail('Should be able to walk away from the coffee machine');
-      }
-    );
-  });
+
+  // Check all screenshots.
   casper.then(function now_check_the_screenshots() {
     // compare screenshots
     phantomcss.compareAll();
   });
-  /*
-  Casper runs tests
-  */
+
+  // Casper runs tests
   casper.run(function () {
     console.log('\nTHE END.');
     // phantomcss.getExitStatus() // pass or fail?


### PR DESCRIPTION
A visual regression test is added with PhantomCSS. Then we can safely re-architecting the css files. I didn't submit the baseline screenshots since they are 8MB. I have no idea about if you would like to keep that in the repository.

Not all functionalities are included in the test suite. Since I have to dig into the code to discover all interactions that triggered the UI changes. So the test suite is not completed.

Usage:

1. install the dependencies
2. start the development server with gulp
3. run `npm test`

Initial sceenshots will be generated into `tests/screenshots`, which currently ignored by git.