### PR TITLE
build: update custom.css

### DIFF
--- a/build/css/custom.css
+++ b/build/css/custom.css
@@ -912,7 +912,7 @@ a:focus {
 }
 footer {
     background: #fff;
-    padding: 15px 20px;
+    padding: 10px 20px;
     display: block
 }
 .nav-sm footer {


### PR DESCRIPTION
Fix white footer's background being visible on the sidebar when using fixed footer layout. It happens when the page gets bigger than the sidebar, so the page footer's background gets showed. I fixed it by setting the page footer's size equal to the sidebar footer's size.