### PR TITLE
style: Update custom.scss

### DIFF
--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -693,7 +693,7 @@ a:hover, a:focus {
 }
 footer {
   background: #fff;
-  padding: 15px 20px;
+  padding: 10px 20px;
   display: block;
 }
 


### PR DESCRIPTION
Fix white footer's background being visible on the sidebar when using fixed footer layout. It happens when the page gets bigger than the sidebar, so the page footer's background gets showed. I fixed it by setting the page footer's size equal to the sidebar footer's size.


![Example error](https://i.imgur.com/lehKBwc.png)