### PR TITLE
Fix Spinner Icons in spin when add .fa-spin class in Icons.html

### DIFF
--- a/production/icons.html
+++ b/production/icons.html
@@ -1354,12 +1354,12 @@
                         <ul class="fa-ul">
                           <li>
                             <i class="fa fa-info-circle fa-lg fa-li"></i> These icons work great with the <code>fa-spin</code> class. Check out the
-                            <a href="../examples/#spinning" class="alert-link">spinning icons example</a>.
+                            <a href="../examples/#spinning" id="sping-icons" class="alert-link">spinning icons example</a>.
                           </li>
                         </ul>
                       </div>
 
-                      <div class="row fontawesome-icon-list">
+                      <div class="row fontawesome-icon-list ready-spin">
 
 
 
@@ -2344,5 +2344,17 @@
 
     <!-- Custom Theme Scripts -->
     <script src="../build/js/custom.min.js"></script>
+    <script>
+        $(function () {
+            $(document).on('click', '#sping-icons', function (e) {
+                e.preventDefault();
+                if ($('.ready-spin').find('i.fa').hasClass('fa-spin')) {
+                    $('.ready-spin').find('i.fa').removeClass('fa-spin');
+                } else {
+                    $('.ready-spin').find('i.fa').addClass('fa-spin');
+                }
+            })
+        });
+   </script>
   </body>
 </html>

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -1710,7 +1710,6 @@ h4.graph_title {
   vertical-align: -6px;
 }
 .fontawesome-icon-list .fa-hover a .fa {
-  width: 32px;
   font-size: 16px;
   display: inline-block;
   text-align: right;


### PR DESCRIPTION
Fix Spinner Icons in spin when add `.fa-spin` class in Icons.html
Fix `spinning icons example` link,when click on it add `.fa-spin` to icons