### PR TITLE
Bug fix of multilevel menu in the small mode.

### DIFF
--- a/build/js/custom.js
+++ b/build/js/custom.js
@@ -87,8 +87,8 @@ var setContentHeight = function () {
             {
 				if ( $BODY.is( ".nav-sm" ) )
 				{
-					$SIDEBAR_MENU.find( "li" ).removeClass( "active active-sm" );
-					$SIDEBAR_MENU.find( "li ul" ).slideUp();
+					$li.parent().find( "li" ).removeClass( "active active-sm" );
+					$li.parent().find( "li ul" ).slideUp();
 				}
 			}
             $li.addClass('active');


### PR DESCRIPTION
When the sidebar is in the small mode, there is a bug of multilevel menu. When I cliked the Level-One menu which has some Level-Two menus, those Level-Two menus will not be shown, even that Level-One menu will be closed. Refering to the code, it is because all the menus of $SIDEBAR_MENU has been closed. I assume that the orginal idea is to close those opened menu in the parent level for example the Level-One which has several Level-Two menus.